### PR TITLE
EKA-150 | Fixing diagnosticReport observation reference errors. 

### DIFF
--- a/src/components/DiagnosticReport/DiagnosticReportComponent.js
+++ b/src/components/DiagnosticReport/DiagnosticReportComponent.js
@@ -42,7 +42,13 @@ const DiagnosticReportComponent = ({ data, consentReqId }) => {
 
   function getResultsList(results, resourceType) {
     const referenceList = [];
-    if (results) results.forEach((result) => referenceList.push(result.targetResource));
+    if (results) { 
+      results.forEach((result) => {
+        if (result.targetResource)  {
+          referenceList.push(result.targetResource);
+        }
+      });
+    }
     return referenceList.filter((ref) => (ref.resourceType === resourceType));
   }
 

--- a/src/components/common/HealthInfo/BundleContext.js
+++ b/src/components/common/HealthInfo/BundleContext.js
@@ -5,15 +5,30 @@ export class BundleContext {
 
   findReference(resourceType, reference) {
     const entry = this.bundle.entry.find((e) => {
-      if (!resourceType) {
-        return reference.includes(e.resource.id);
-      }
       if (e.resource.resourceType.toLowerCase() === resourceType.toLowerCase()) {
-        // TODO very simplistic includes. we would need regex
-        return reference.includes(e.resource.id);
+        const resourceId = this.getEntryResourceId(e);
+        if (resourceId) {
+          return reference.includes(resourceId);
+        }
       }
       return false;
     });
     return entry ? entry.resource : undefined;
+  }
+
+  getEntryResourceId(entry) {
+    if (entry.resource.id) {
+      return entry.resource.id;
+    }
+
+    if (entry.fullUrl) {
+      console.warn("Falling back on default implementation of looking into fullUrl. Resource id is undefined. This should have never happenned. Bundle entry fullUrl=" + entry.fullUrl);
+      // TODO very simplistic regex, looking for the last colon till the end. will work for urn:uuid:id or similar. 
+      const matches = entry.fullUrl.match(/[^:]+$/);
+      if (matches) {
+        return matches[0];
+      }
+    }
+    return undefined;
   }
 }


### PR DESCRIPTION
Also fixing the issue if the resource.id is not present. Although resource.id should always be present. Needs more investigation